### PR TITLE
Task 6. Add AWS SQS and SNS

### DIFF
--- a/import-service/handlers/constants.ts
+++ b/import-service/handlers/constants.ts
@@ -3,3 +3,5 @@ import AWS from 'aws-sdk';
 export const awsImportBucket = 'aws-import-s3';
 
 export const s3 = new AWS.S3({ region: 'eu-west-1' });
+
+export const sqs = new AWS.SQS();

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -15,12 +15,14 @@ const serverlessConfiguration: Serverless = {
   provider: {
     name: 'aws',
     runtime: 'nodejs12.x',
+    stage: 'dev',
     region: 'eu-west-1',
     apiGateway: {
       minimumCompressionSize: 1024,
     },
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      PRODUCT_SQS_URL: { 'Fn::ImportValue': 'catalogItemsQueueUrl' },
     },
     iamRoleStatements: [
       {
@@ -32,6 +34,11 @@ const serverlessConfiguration: Serverless = {
         Effect: 'Allow',
         Action: 's3:*',
         Resource: 'arn:aws:s3:::aws-import-s3/*',
+      },
+      {
+        Effect: 'Allow',
+        Action: 'sqs:*',
+        Resource: { 'Fn::ImportValue': 'catalogItemsQueueArn' },
       },
     ],
   },

--- a/product-service/data-access/typings.ts
+++ b/product-service/data-access/typings.ts
@@ -7,7 +7,22 @@ export interface Product {
   count: number;
 }
 
+export interface ProductBody {
+  title: string;
+  description: string;
+  price: number | string;
+  image_url: string;
+}
+
 export interface Stock {
   product_id: string;
   count: number;
 }
+
+export interface StockBody {
+  count: number | string;
+}
+
+export type ProductWithStock = Product & Omit<Stock, 'product_id'>;
+
+export type ProductWithStockBody = ProductBody & StockBody;

--- a/product-service/handler.ts
+++ b/product-service/handler.ts
@@ -1,3 +1,3 @@
 import 'source-map-support/register';
 
-export * from './handlers'
+export * from './handlers';

--- a/product-service/handlers/api/addProduct.test.ts
+++ b/product-service/handlers/api/addProduct.test.ts
@@ -1,0 +1,58 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+
+import { ProductWithStock, ProductWithStockBody } from '../../data-access';
+import { ProductService } from '../../services/product';
+import { addProduct } from './addProduct';
+
+jest.mock('../../services/product');
+
+describe('addProduct', () => {
+  let event: APIGatewayProxyEvent;
+  let _context: Context;
+  let cb: jest.Mock;
+  let productBody: ProductWithStockBody;
+  let product: ProductWithStock;
+
+  beforeEach(() => {
+    productBody = {
+      title: 'title',
+      description: 'description',
+      price: 1000,
+      image_url: 'https://image-url/',
+      count: 10,
+    };
+    event = ({
+      body: JSON.stringify(productBody),
+    } as unknown) as APIGatewayProxyEvent;
+    _context = { functionName: 'addProduct' } as Context;
+    cb = jest.fn();
+
+    product = {
+      id: '5802483b-16e5-4347-a648-1bead3529489',
+      ...productBody
+    } as ProductWithStock;
+
+    (ProductService.prototype.createProduct as jest.Mock).mockResolvedValue(product);
+  });
+
+  it('should respond with a product when the product was created', async () => {
+    const response = {
+      statusCode: 201,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Credentials': true,
+      },
+      body: JSON.stringify(product),
+    };
+
+    expect(await addProduct(event, _context, cb)).toEqual(response);
+  });
+
+  it('should respond with error message on error', async () => {
+    (ProductService.prototype.createProduct as jest.Mock).mockRejectedValue(new Error('Error'));
+
+    const response = { statusCode: 500, body: JSON.stringify('Unhandled error: Error') };
+
+    expect(await addProduct(event, _context, cb)).toEqual(response);
+  });
+});

--- a/product-service/handlers/catalogBatchProcess.test.ts
+++ b/product-service/handlers/catalogBatchProcess.test.ts
@@ -1,0 +1,92 @@
+import { Context, SQSEvent } from 'aws-lambda';
+
+import { ProductWithStock, ProductWithStockBody } from '../data-access';
+import { publishSns, Cost } from './utils/publishSns';
+import { ProductService } from '../services/product';
+import { catalogBatchProcess } from './catalogBatchProcess';
+
+jest.mock('../services/product');
+jest.mock('./utils/publishSns');
+
+describe('catalogBatchProcess', () => {
+  let event: SQSEvent;
+  let _context: Context;
+  let cb: jest.Mock;
+  let productsBody: ProductWithStockBody[];
+  let products: ProductWithStock[];
+
+  beforeEach(() => {
+    productsBody = ([
+      {
+        title: 'title-1',
+        description: 'description',
+        price: '1000',
+        image_url: 'https://image-url-1/',
+        count: '10',
+      },
+      {
+        title: 'title-2',
+        description: 'description',
+        price: '2000',
+        image_url: 'https://image-url-2/',
+        count: '20',
+      },
+    ] as unknown) as ProductWithStockBody[];
+
+    event = ({
+      Records: [
+        { body: JSON.stringify(productsBody[0]) },
+        { body: JSON.stringify(productsBody[1]) },
+      ],
+    } as unknown) as SQSEvent;
+    _context = { functionName: 'catalogBatchProcess' } as Context;
+    cb = jest.fn();
+
+    products = [
+      {
+        id: 'id-1',
+        title: 'title-1',
+        description: 'description-1',
+        price: 500,
+        image_url: 'https://image-url-1/',
+        count: 13,
+      },
+      {
+        id: 'id-2',
+        title: 'title-2',
+        description: 'description-2',
+        price: 1000,
+        image_url: 'https://image-url-2/',
+        count: 20,
+      },
+    ];
+
+    (ProductService.prototype.createProducts as jest.Mock).mockResolvedValue(products);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should add new products on catalog batch process', async () => {
+    await catalogBatchProcess(event, _context, cb);
+
+    expect(ProductService.prototype.createProducts).toHaveBeenCalledWith(productsBody);
+  });
+
+  it('should send a message to an amazon sns topic via email about successful product creation for budget and expensive products', async () => {
+    await catalogBatchProcess(event, _context, cb);
+
+    expect(publishSns).toHaveBeenCalledWith(Cost.Budget, [products[0]]);
+    expect(publishSns).toHaveBeenCalledWith(Cost.Expensive, [products[1]]);
+  });
+
+  it('should NOT send a message to an amazon sns topic via email about successful product creation when products were not created', async () => {
+    (ProductService.prototype.createProducts as jest.Mock).mockResolvedValue([]);
+
+    await catalogBatchProcess(event, _context, cb);
+
+    expect(publishSns).not.toHaveBeenCalledWith(Cost.Budget, [products[0]]);
+    expect(publishSns).not.toHaveBeenCalledWith(Cost.Expensive, [products[1]]);
+  });
+});

--- a/product-service/handlers/catalogBatchProcess.test.ts
+++ b/product-service/handlers/catalogBatchProcess.test.ts
@@ -1,7 +1,7 @@
 import { Context, SQSEvent } from 'aws-lambda';
 
 import { ProductWithStock, ProductWithStockBody } from '../data-access';
-import { publishSns, Cost } from './utils/publishSns';
+import { publishSns } from './utils/publishSns';
 import { ProductService } from '../services/product';
 import { catalogBatchProcess } from './catalogBatchProcess';
 
@@ -77,8 +77,7 @@ describe('catalogBatchProcess', () => {
   it('should send a message to an amazon sns topic via email about successful product creation for budget and expensive products', async () => {
     await catalogBatchProcess(event, _context, cb);
 
-    expect(publishSns).toHaveBeenCalledWith(Cost.Budget, [products[0]]);
-    expect(publishSns).toHaveBeenCalledWith(Cost.Expensive, [products[1]]);
+    expect(publishSns).toHaveBeenCalledWith(products);
   });
 
   it('should NOT send a message to an amazon sns topic via email about successful product creation when products were not created', async () => {
@@ -86,7 +85,6 @@ describe('catalogBatchProcess', () => {
 
     await catalogBatchProcess(event, _context, cb);
 
-    expect(publishSns).not.toHaveBeenCalledWith(Cost.Budget, [products[0]]);
-    expect(publishSns).not.toHaveBeenCalledWith(Cost.Expensive, [products[1]]);
+    expect(publishSns).not.toHaveBeenCalledWith(products);
   });
 });

--- a/product-service/handlers/catalogBatchProcess.ts
+++ b/product-service/handlers/catalogBatchProcess.ts
@@ -2,7 +2,7 @@
 import { SQSHandler } from 'aws-lambda';
 
 import { ProductService } from '../services/product';
-import { Cost, publishSns } from './utils';
+import { publishSns } from './utils';
 
 const Product = new ProductService();
 
@@ -14,15 +14,8 @@ export const catalogBatchProcess: SQSHandler = async ({ Records }) => {
 
     const products = await Product.createProducts(productsBody);
 
-    const budgetProducts = products?.filter(({ price }) => price <= 500);
-    const expensiveProducts = products?.filter(({ price }) => price > 500);
-
-    if (budgetProducts?.length) {
-      await publishSns(Cost.Budget, budgetProducts);
-    }
-
-    if (expensiveProducts?.length) {
-      await publishSns(Cost.Expensive, expensiveProducts);
+    if (products?.length) {
+      await publishSns(products);
     }
   } catch (err) {
     console.log('Catalog batch error', err.message);

--- a/product-service/handlers/catalogBatchProcess.ts
+++ b/product-service/handlers/catalogBatchProcess.ts
@@ -1,0 +1,30 @@
+
+import { SQSHandler } from 'aws-lambda';
+
+import { ProductService } from '../services/product';
+import { Cost, publishSns } from './utils';
+
+const Product = new ProductService();
+
+export const catalogBatchProcess: SQSHandler = async ({ Records }) => {
+  try {
+    console.log('catalog batch process', Records);
+
+    const productsBody = Records.map(({ body }) => JSON.parse(body));
+
+    const products = await Product.createProducts(productsBody);
+
+    const budgetProducts = products?.filter(({ price }) => price <= 500);
+    const expensiveProducts = products?.filter(({ price }) => price > 500);
+
+    if (budgetProducts?.length) {
+      await publishSns(Cost.Budget, budgetProducts);
+    }
+
+    if (expensiveProducts?.length) {
+      await publishSns(Cost.Expensive, expensiveProducts);
+    }
+  } catch (err) {
+    console.log('Catalog batch error', err.message);
+  }
+};

--- a/product-service/handlers/constants.ts
+++ b/product-service/handlers/constants.ts
@@ -1,0 +1,3 @@
+import AWS from 'aws-sdk';
+
+export const sns = new AWS.SNS({ region: 'eu-west-1' });

--- a/product-service/handlers/index.ts
+++ b/product-service/handlers/index.ts
@@ -1,1 +1,2 @@
-export * from './api'
+export * from './api';
+export * from './catalogBatchProcess';

--- a/product-service/handlers/utils/index.ts
+++ b/product-service/handlers/utils/index.ts
@@ -1,2 +1,3 @@
-export * from './createResponse'
-export * from './handleError'
+export * from './createResponse';
+export * from './handleError';
+export * from './publishSns';

--- a/product-service/handlers/utils/publishSns.test.ts
+++ b/product-service/handlers/utils/publishSns.test.ts
@@ -1,0 +1,83 @@
+import { Cost, publishSns } from './publishSns';
+import AWSMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+
+import { ProductWithStock } from '../../data-access';
+
+const mockAwsInstance = jest.fn();
+
+jest.mock('../constants', () => ({
+  get sns() {
+    return mockAwsInstance();
+  },
+}));
+
+describe('publishSns', () => {
+  let mockSNS: AWS.SNS;
+  let products: ProductWithStock[];
+
+  beforeEach(() => {
+    products = [
+      {
+        id: 'id-1',
+        title: 'title-1',
+        description: 'description-1',
+        price: 500,
+        image_url: 'https://image-url-1/',
+        count: 13,
+      },
+      {
+        id: 'id-2',
+        title: 'title-2',
+        description: 'description-2',
+        price: 1000,
+        image_url: 'https://image-url-2/',
+        count: 20,
+      },
+    ];
+
+    AWSMock.setSDKInstance(AWS);
+    AWSMock.mock('SNS', 'publish', (params: any, callback: Function) => callback(null, {}));
+
+    mockSNS = new AWS.SNS();
+    mockAwsInstance.mockReturnValue(mockSNS);
+  });
+
+  it('should send a message to AWS SNS topic for budget products subscription', async () => {
+    const publishSpy = jest.spyOn(mockSNS, 'publish');
+
+    const params = {
+      Subject: 'Products were successfully created',
+      Message: `We would like to inform you that the following products have been created: \n ${JSON.stringify(
+        [products[0]],
+        null,
+        2
+      )} \n`,
+      TopicArn: process.env.SNS_ARN,
+      MessageAttributes: {
+        cost: { DataType: 'String', StringValue: Cost.Budget },
+      },
+    };
+
+    await publishSns(products);
+
+    expect(publishSpy).toHaveBeenCalledWith(params);
+  });
+
+  it('should send a message to AWS SNS topic for expensive products subscription', async () => {
+    const publishSpy = jest.spyOn(mockSNS, 'publish');
+
+    const params = {
+      Subject: 'Products were successfully created',
+      Message: `We would like to inform you that the following products have been created: \n ${JSON.stringify([products[1]], null, 2)} \n`,
+      TopicArn: process.env.SNS_ARN,
+      MessageAttributes: {
+        cost: { DataType: 'String', StringValue: Cost.Expensive },
+      },
+    };
+
+    await publishSns(products);
+
+    expect(publishSpy).toHaveBeenCalledWith(params);
+  });
+});

--- a/product-service/handlers/utils/publishSns.ts
+++ b/product-service/handlers/utils/publishSns.ts
@@ -1,0 +1,24 @@
+import AWS from 'aws-sdk';
+
+import { ProductWithStock } from '../../data-access';
+
+export enum Cost {
+  Budget = 'budget',
+  Expensive = 'expensive',
+}
+
+export const publishSns = async (cost: Cost, products: ProductWithStock[]) => {
+  const sns = new AWS.SNS({ region: 'eu-west-1' });
+
+  const publishParams = {
+    Subject: 'Product were successfully created',
+    Message: `We would like to inform you that the following products have been created:
+    \n ${JSON.stringify(products, null, 2)} \n`,
+    TopicArn: process.env.SNS_ARN,
+    MessageAttributes: {
+      cost: { DataType: 'String', StringValue: cost },
+    },
+  };
+
+  await sns.publish(publishParams).promise();
+};

--- a/product-service/package.json
+++ b/product-service/package.json
@@ -10,6 +10,7 @@
     "swagger:edit": "swagger project edit"
   },
   "dependencies": {
+    "aws-sdk": "^2.795.0",
     "pg": "^8.4.2",
     "source-map-support": "^0.5.10"
   },
@@ -22,6 +23,7 @@
     "@types/node": "^10.12.18",
     "@types/pg": "^7.14.6",
     "@types/serverless": "^1.72.5",
+    "aws-sdk-mock": "^5.1.0",
     "fork-ts-checker-webpack-plugin": "^3.0.1",
     "jest": "^26.6.1",
     "serverless-dotenv-plugin": "^3.1.0",

--- a/product-service/serverless.ts
+++ b/product-service/serverless.ts
@@ -1,4 +1,4 @@
-import type { Serverless } from 'serverless/aws';
+import { Serverless } from 'serverless/aws';
 
 const serverlessConfiguration: Serverless = {
   service: {
@@ -27,6 +27,76 @@ const serverlessConfiguration: Serverless = {
       DB_PASSWORD: '${env:DB_PASSWORD}',
       DB_HOST: '${env:DB_HOST}',
       DB_PORT: '${env:DB_PORT}',
+      SQS_URL: { Ref: 'SQSQueue' },
+      SNS_ARN: { Ref: 'SNSTopic' },
+    },
+    iamRoleStatements: [
+      {
+        Effect: 'Allow',
+        Action: 'sqs:*',
+        Resource: { 'Fn::GetAtt': ['SQSQueue', 'Arn'] },
+      },
+      {
+        Effect: 'Allow',
+        Action: 'sns:*',
+        Resource: { Ref: 'SNSTopic' },
+      },
+    ],
+  },
+  resources: {
+    Resources: {
+      SQSQueue: {
+        Type: 'AWS::SQS::Queue',
+        Properties: {
+          QueueName: 'catalogItemsQueue',
+        },
+      },
+      SNSTopic: {
+        Type: 'AWS::SNS::Topic',
+        Properties: {
+          TopicName: 'createProductTopic',
+        },
+      },
+      SNSSubscription: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint: 'node.aws.sns@gmail.com',
+          Protocol: 'email',
+          TopicArn: { Ref: 'SNSTopic' },
+          FilterPolicy: {
+            cost: ['budget'],
+          },
+        },
+      },
+      SNSFilterSubscription: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint: 'node.aws.sns.filter@gmail.com',
+          Protocol: 'email',
+          TopicArn: { Ref: 'SNSTopic' },
+          FilterPolicy: {
+            cost: ['expensive'],
+          },
+        },
+      },
+    },
+    Outputs: {
+      catalogItemsQueueUrl: {
+        Value: {
+          Ref: 'SQSQueue',
+        },
+        Export: {
+          Name: 'catalogItemsQueueUrl',
+        },
+      },
+      catalogItemsQueueArn: {
+        Value: {
+          'Fn::GetAtt': ['SQSQueue', 'Arn'],
+        },
+        Export: {
+          Name: 'catalogItemsQueueArn',
+        },
+      },
     },
   },
   functions: {
@@ -62,6 +132,19 @@ const serverlessConfiguration: Serverless = {
             method: 'post',
             path: 'products',
             cors: true,
+          },
+        },
+      ],
+    },
+    catalogBatchProcess: {
+      handler: 'handler.catalogBatchProcess',
+      events: [
+        {
+          sqs: {
+            arn: {
+              'Fn::GetAtt': ['SQSQueue', 'Arn'],
+            },
+            batchSize: 5,
           },
         },
       ],

--- a/product-service/serverless.ts
+++ b/product-service/serverless.ts
@@ -27,7 +27,6 @@ const serverlessConfiguration: Serverless = {
       DB_PASSWORD: '${env:DB_PASSWORD}',
       DB_HOST: '${env:DB_HOST}',
       DB_PORT: '${env:DB_PORT}',
-      SQS_URL: { Ref: 'SQSQueue' },
       SNS_ARN: { Ref: 'SNSTopic' },
     },
     iamRoleStatements: [
@@ -57,7 +56,7 @@ const serverlessConfiguration: Serverless = {
           TopicName: 'createProductTopic',
         },
       },
-      SNSSubscription: {
+      SNSBudgetSubscription: {
         Type: 'AWS::SNS::Subscription',
         Properties: {
           Endpoint: 'node.aws.sns@gmail.com',
@@ -68,7 +67,7 @@ const serverlessConfiguration: Serverless = {
           },
         },
       },
-      SNSFilterSubscription: {
+      SNSExpensiveSubscription: {
         Type: 'AWS::SNS::Subscription',
         Properties: {
           Endpoint: 'node.aws.sns.filter@gmail.com',

--- a/product-service/services/product/constants.ts
+++ b/product-service/services/product/constants.ts
@@ -1,0 +1,2 @@
+export const defaultImgUrl =
+  'https://lp-cms-production.imgix.net/features/2019/05/Solo-Travel-in-Nature-acbfea52bfaf.jpg';

--- a/product-service/services/product/stockQueries.ts
+++ b/product-service/services/product/stockQueries.ts
@@ -5,23 +5,11 @@ export const createStockTableQuery = `
   )
 `;
 
-export const addStockItemsQuery = (productIds: Record<string, string>[]) => {
-  const stocks = productIds.map(({ id }) => ({
-    id,
-    count: Math.floor(Math.random() * (100 - 1) + 1),
-  }));
-
-  const stocksQuery = stocks.map(({ id, count }) => [`'${id}'`, count]).join('), \n (');
-
-  return `
-    insert into stocks (product_id, count) values
-      (${stocksQuery}) on conflict do nothing
-  `;
-};
+export const addStockItemsQuery = `
+  insert into stocks (product_id, count) select * from unnest ($1::uuid[], $2::int[]) on conflict do nothing`;
 
 export const getProductIdsQuery = `select id from products`;
 
 export const getStockItemsQuery = `select * from stocks`;
 
-export const createStockQuery = `insert into stocks (product_id, count) values ($1, $2) returning *`
-
+export const createStockQuery = `insert into stocks (product_id, count) values ($1, $2) returning *`;

--- a/product-service/services/product/utils/getAddProductsQueryValues.test.ts
+++ b/product-service/services/product/utils/getAddProductsQueryValues.test.ts
@@ -1,0 +1,34 @@
+import { getAddProductsQueryValues } from './getAddProductsQueryValues';
+
+describe('getAddProductsQueryValues', () => {
+  it('should return a nested list with a list for each param', () => {
+    const products = [
+      {
+        id: '1268154c-4f85-42b4-8114-04ecaf7e3626',
+        title: 'The weekend in Cappadocia',
+        description: 'Do you dream of a land',
+        price: 1000,
+        image_url: 'https://ulr/image1.jpg',
+        count: 1,
+      },
+      {
+        id: '66009e29-387f-498b-a876-6afca76d9d48',
+        title: 'Erciyes ski New Year tour',
+        description: 'Skiing is one of the best activity',
+        price: 1500,
+        image_url: 'https://ulr/image2.jpg',
+        count: 7,
+      },
+    ];
+
+    const queryValues = [
+      ['The weekend in Cappadocia', 'Erciyes ski New Year tour'],
+      ['Do you dream of a land', 'Skiing is one of the best activity'],
+      [1000, 1500],
+      ['https://ulr/image1.jpg', 'https://ulr/image2.jpg'],
+      [1, 7],
+    ];
+
+    expect(getAddProductsQueryValues(products)).toEqual(queryValues);
+  });
+});

--- a/product-service/services/product/utils/getAddProductsQueryValues.ts
+++ b/product-service/services/product/utils/getAddProductsQueryValues.ts
@@ -1,0 +1,17 @@
+import { Product } from '../../../data-access';
+
+type AddProductsQueryValues = Array<(string | number)[]>;
+
+export const getAddProductsQueryValues = (products: Omit<Product, 'id'>[]) =>
+  products.reduce(
+    (values: AddProductsQueryValues, { title, description, price, image_url, count }) => {
+      [title, description, price, image_url, count]
+        .filter(el => !!el)
+        .forEach((el, i) => {
+          values[i] = values[i] ? [...values[i], el] : [el];
+        });
+
+      return values;
+    },
+    []
+  );

--- a/product-service/services/product/utils/getAddStockQueryValues.test.ts
+++ b/product-service/services/product/utils/getAddStockQueryValues.test.ts
@@ -1,0 +1,19 @@
+import { getAddStockQueryValues } from './getAddStockQueryValues';
+
+describe('getAddStockQueryValues', () => {
+  it('should return a nested list with a list for each param with random stock value', () => {
+    Math.floor = jest.fn().mockReturnValue(1);
+
+    const productIds = [
+      { id: '1268154c-4f85-42b4-8114-04ecaf7e3626' },
+      { id: '66009e29-387f-498b-a876-6afca76d9d48' },
+    ];
+
+    const queryValues = [
+      ['1268154c-4f85-42b4-8114-04ecaf7e3626', '66009e29-387f-498b-a876-6afca76d9d48'],
+      [1, 1],
+    ];
+
+    expect(getAddStockQueryValues(productIds)).toEqual(queryValues);
+  });
+});

--- a/product-service/services/product/utils/getAddStockQueryValues.ts
+++ b/product-service/services/product/utils/getAddStockQueryValues.ts
@@ -1,0 +1,9 @@
+export const getAddStockQueryValues = (productIds: Record<string, string>[]) => {
+  const productIdList = productIds.map(({ id }) => id);
+  
+  const countList = [...Array(productIds.length)].map(() =>
+    Math.floor(Math.random() * (30 - 1) + 1)
+  );
+
+  return [productIdList, countList];
+};

--- a/product-service/services/product/utils/index.ts
+++ b/product-service/services/product/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './getAddStockQueryValues';
+export * from './getAddProductsQueryValues';
+export * from './parseProducts';

--- a/product-service/services/product/utils/parseProducts.test.ts
+++ b/product-service/services/product/utils/parseProducts.test.ts
@@ -1,0 +1,42 @@
+import { defaultImgUrl } from '../constants';
+import { parseProducts } from './parseProducts';
+
+describe('parseProduct', () => {
+  it('should return a parsed product', () => {
+    const products = [
+      {
+        title: 'Trip 1',
+        description: 'desc',
+        price: '1000',
+        image_url: 'url-1',
+        count: '6',
+      },
+      {
+        title: 'Trip 2',
+        description: 'desc',
+        price: '2000',
+        image_url: '',
+        count: '12',
+      },
+    ];
+
+    const parsedProducts = [
+      {
+        title: 'Trip 1',
+        description: 'desc',
+        price: 1000,
+        image_url: 'url-1',
+        count: 6,
+      },
+      {
+        title: 'Trip 2',
+        description: 'desc',
+        price: 2000,
+        image_url: defaultImgUrl,
+        count: 12,
+      },
+    ];
+
+    expect(parseProducts(products)).toEqual(parsedProducts);
+  });
+});

--- a/product-service/services/product/utils/parseProducts.ts
+++ b/product-service/services/product/utils/parseProducts.ts
@@ -1,0 +1,18 @@
+import { ProductWithStock, ProductWithStockBody } from '../../../data-access';
+import { defaultImgUrl } from '../constants';
+
+export const parseProduct = ({
+  title,
+  description,
+  price,
+  image_url = defaultImgUrl,
+  count,
+}: ProductWithStockBody): Omit<ProductWithStock, 'id'> => ({
+  title,
+  description,
+  price: Number(price),
+  image_url: image_url ? image_url : defaultImgUrl,
+  count: Number(count),
+});
+
+export const parseProducts = (products: ProductWithStockBody[]) => products.map(parseProduct);

--- a/product-service/yarn.lock
+++ b/product-service/yarn.lock
@@ -1087,19 +1087,41 @@
   dependencies:
     stream "^0.0.2"
 
-"@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
   integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^6.0.1":
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.2.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.0.tgz#1d2f0743dc54bf13fe9d508baefacdffa25d4329"
+  integrity sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@types/aws-lambda@^8.10.17":
   version "8.10.64"
@@ -1694,6 +1716,45 @@ autolinker@^3.11.0:
   dependencies:
     tslib "^1.9.3"
 
+aws-sdk-mock@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-5.1.0.tgz#6f2c0bd670d7f378c906a8dd806f812124db71aa"
+  integrity sha512-Wa5eCSo8HX0Snqb7FdBylaXMmfrAWoWZ+d7MFhiYsgHPvNvMEGjV945FF2qqE1U0Tolr1ALzik1fcwgaOhqUWQ==
+  dependencies:
+    aws-sdk "^2.637.0"
+    sinon "^9.0.1"
+    traverse "^0.6.6"
+
+aws-sdk@^2.637.0:
+  version "2.797.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.797.0.tgz#e9510a582606a580e7bbb686f01da28476599a2d"
+  integrity sha512-fFc/2Xr7NkSXlZ9+2rCOFovA9NO1OnIyEaJFVwMM9gaqzucwRAfNNT0Pa1Kua5dhWrcf/mX0Z4mCDnTBf0/5mA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.795.0:
+  version "2.795.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.795.0.tgz#30984ff6e6df4e98b9fff5994146d3b20e40adfc"
+  integrity sha512-cqMposguHdiZOgS3HpAvA8iP3vfrlPQCCn5RllpzU3gPIP5RKtcACu6qzwIAZGcMvC0qt49EzAzyIfN+qdzikQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2059,7 +2120,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -2947,7 +3008,7 @@ diff@1.4.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
   integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
 
-diff@^4.0.1:
+diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -3240,6 +3301,11 @@ event-emitter@^0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 events@^3.0.0:
   version "3.2.0"
@@ -4040,6 +4106,11 @@ iconv-lite@^0.6.2:
   integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
@@ -4958,6 +5029,11 @@ jest@^26.6.1:
     import-local "^3.0.2"
     jest-cli "^26.6.1"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
 js-file-download@^0.4.1:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
@@ -5149,6 +5225,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5437,7 +5518,7 @@ lodash.forown@~2.4.1:
     lodash._objecttypes "~2.4.1"
     lodash.keys "~2.4.1"
 
-lodash.get@^4.0.0:
+lodash.get@^4.0.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -5962,6 +6043,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-fetch@1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
@@ -6404,7 +6496,7 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-to-regexp@^1.2.0:
+path-to-regexp@^1.2.0, path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
@@ -7415,6 +7507,16 @@ sanitize-filename@^1.3.0:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 saxes@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -7599,6 +7701,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+sinon@^9.0.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.1.tgz#64cc88beac718557055bd8caa526b34a2231be6d"
+  integrity sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.2.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -8463,7 +8578,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8:
+type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -8667,6 +8782,14 @@ url-parse@^1.4.7:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0, url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -8708,6 +8831,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2:
   version "3.4.0"
@@ -8998,6 +9126,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Task 6 [https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task6-sqs-sns/task.md](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task6-sqs-sns/task.md)

All required and additional tasks were done.
1 - File serverless.yml contains configuration for catalogBatchProcess function
2 - File serverless.yml contains policies to allow lambda catalogBatchProcess function to interact with SNS and SQS
3 - File serverless.yml contains configuration for SQS catalogItemsQueue
4 - File serverless.yml contains configuration for SNS Topic createProductTopic and email subscription

Additional tasks:
+1 - catalogBatchProcess lambda is covered by unit tests
+1 - set a Filter Policy for SNS createProductTopic in serverless.yml (Create an additional email subscription and distribute messages to different emails depending on the filter for any product attribute)

Cloudfront link [https://d2kdkgfbzg2dbv.cloudfront.net/](https://d2kdkgfbzg2dbv.cloudfront.net/)
csv file properties: title,description,image_url,price,count

Score 6 / 6

Screenshots for both subscriptions:

<img width="636" alt="Screenshot 2020-11-22 at 22 23 14" src="https://user-images.githubusercontent.com/45387587/99916375-a7a1eb80-2d12-11eb-977d-7da18d5762da.png">

<img width="516" alt="Screenshot 2020-11-22 at 22 23 23" src="https://user-images.githubusercontent.com/45387587/99916380-abce0900-2d12-11eb-8b90-1bb55cec823c.png">

